### PR TITLE
Update API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ A professional, modern dashboard for testing and analyzing real estate propertie
 ## 🔑 API Key Setup
 
 1. Get your API key from [Homewise API](https://www.sariphi.ai/api/homewise)
-2. Enter it in the dashboard configuration
-3. Your key is automatically saved in localStorage
+2. Use `https://www.sariphi.ai/api/homewise/avm-analysis` for all AVM analysis requests
+3. Enter your key in the dashboard configuration
+4. Your key is automatically saved in localStorage
 
 ## 📊 Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ A professional, modern dashboard for testing and analyzing real estate propertie
 
 [View Live Dashboard](https://your-app-name.vercel.app)
 
+## 🌐 Deploying to Vercel
+
+1. Install the Vercel CLI: `npm install -g vercel`
+2. Run `npm run deploy` and follow the prompts to create a new Vercel project.
+3. After deployment, Vercel provides a free URL like `https://your-app-name.vercel.app`.
+4. Update the **Live Demo** link above with your new project URL.
+
 ## 💻 Local Development
 
 1. Clone the repository

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A professional, modern dashboard for testing and analyzing real estate propertie
 
 ## 🔑 API Key Setup
 
-1. Get your API key from [Homewise API](https://api.homewise.com)
+1. Get your API key from [Homewise API](https://www.sariphi.ai/api/homewise)
 2. Enter it in the dashboard configuration
 3. Your key is automatically saved in localStorage
 

--- a/index.html
+++ b/index.html
@@ -664,7 +664,7 @@
         // API Call
         async function callHomewiseAPI(addresses, apiKey) {
             try {
-                const response = await axios.post('https://api.homewise.com/avm-analysis', {
+                const response = await axios.post('https://www.sariphi.ai/api/homewise/avm-analysis', {
                     addresses: addresses
                 }, {
                     headers: {
@@ -693,7 +693,7 @@
         async function pollForResults(taskId, apiKey, maxAttempts = 30) {
             for (let i = 0; i < maxAttempts; i++) {
                 try {
-                    const response = await axios.get(`https://api.homewise.com/avm-analysis?id=${taskId}`, {
+                    const response = await axios.get(`https://www.sariphi.ai/api/homewise/avm-analysis?id=${taskId}`, {
                         headers: {
                             'Authorization': `Bearer ${apiKey}`
                         }


### PR DESCRIPTION
## Summary
- switch dashboard API calls to `https://www.sariphi.ai/api/homewise`
- update README with the new API URL

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862b2b50680832fb99f694462b5bfea